### PR TITLE
Single map fix

### DIFF
--- a/bounded-map-creator
+++ b/bounded-map-creator
@@ -11,14 +11,17 @@
 
 # http://wiki.openstreetmap.org/wiki/Osmosis
 
-[ $OSMOSIS_HOME ] || OSMOSIS_HOME="$HOME/programs/osmosis"
-[ $DATA_PATH ] || DATA_PATH="$HOME/mapsforge/data"
-[ $MAPS_PATH ] || MAPS_PATH="$HOME/mapsforge/maps"
-[ $POIS_PATH ] || POIS_PATH="$HOME/mapsforge/pois"
+[ $OSMOSIS_HOME ] || OSMOSIS_HOME="/home/dnesbitt/osmosis"
+[ $DATA_PATH ] || DATA_PATH="./mapsforge/data"
+[ $MAPS_PATH ] || MAPS_PATH="./mapsforge/maps"
+[ $POIS_PATH ] || POIS_PATH="./mapsforge/pois"
 [ $PROGRESS_LOGS ] || PROGRESS_LOGS="true"
 [ $TAG_VALUES ] || TAG_VALUES="false"
-[ $THREADS ] || THREADS="1"
-[ $DAYS ] || DAYS="30"
+[ $THREADS ] || THREADS="12"
+[ $DAYS ] || DAYS="7"
+[ $MAP_TAG_CONF_FILE ] || MAP_TAG_CONF_FILE="./tag-mapping.xml"
+[ $SKIP_MAP_CREATION ] || SKIP_MAP_CREATION="false"
+[ $SKIP_POI_CREATION ] || SKIP_POI_CREATION="true"
 
 # =========== DO NOT CHANGE AFTER THIS LINE. ===========================
 # Below here is regular code, part of the file. This is not designed to
@@ -26,27 +29,27 @@
 # ======================================================================
 
 if [ $# -lt 3 ]; then
-  echo "Usage: $0 continent/country[/region] buffer_size ram|hd [lang,...]"
-  echo "Example: $0 europe/germany/berlin 0.1 ram en,de,fr,es"
+  echo "Usage: $0 continent country minlon minlat maxlon maxlat centerlon centerlat ram|hd [lang,...]"
+  echo "Example: $0 central-america bahamas -79.0 20.0 -70.0 27.0 -74.5 23.5 ram en,de,fr,es"
   exit
 fi
 
 cd "$(dirname "$0")"
 
-NAME="$(basename "$1")"
+NAME="$2"
 WORK_PATH="$DATA_PATH/$1"
-BUFFER_SIZE="$2"
 
 if [ "$TAG_VALUES" = "true" ]; then
   MAPS_PATH="$MAPS_PATH/v5"
 else
-  [ $3 ] && MAPS_PATH="$MAPS_PATH/v4" || MAPS_PATH="$MAPS_PATH/v3"
+  MAPS_PATH="$MAPS_PATH/v4"
 fi
-MAPS_PATH="$(dirname "$MAPS_PATH/$1")"
 
-POIS_PATH="$(dirname "$POIS_PATH/$1")"
+MAPS_PATH="$(dirname "$MAPS_PATH/$1/$2")"
+POIS_PATH="$(dirname "$POIS_PATH/$1/$2")"
 
 # Check map date
+
 if [ -f "$MAPS_PATH/$NAME.map" ]; then
   if [ $(find "$MAPS_PATH/$NAME.map" -mtime -$DAYS) ]; then
     echo "$MAPS_PATH/$NAME.map exists and is newer than $DAYS days."
@@ -55,7 +58,8 @@ if [ -f "$MAPS_PATH/$NAME.map" ]; then
 fi
 
 # Pre-process
-rm -rf "$WORK_PATH"
+
+#rm -rf "$WORK_PATH"
 mkdir -p "$WORK_PATH"
 
 if [ "$SKIP_MAP_CREATION" != "true" ]; then
@@ -67,6 +71,7 @@ if [ "$SKIP_POI_CREATION" != "true" ]; then
 fi
 
 # Download land
+
 if [ -f "$DATA_PATH/land-polygons-split-4326/land_polygons.shp" ] && [ $(find "$DATA_PATH/land-polygons-split-4326/land_polygons.shp" -mtime -$DAYS) ]; then
   echo "Land polygons exist and are newer than $DAYS days."
 else
@@ -77,50 +82,29 @@ else
   unzip -oq "$DATA_PATH/land-polygons-split-4326.zip" -d "$DATA_PATH"
 fi
 
-#Name override
-if [ "$FILE_NAME" == "" ]; then
-  FILE_NAME=$1
-  FILE_BASE=$NAME
+# Download data
+echo "Check if $WORK_PATH/$1-latest.osm.pbf exists"
+if [ -f "$WORK_PATH/$NAME-latest.osm.pbf" ] && [ $(find "$WORK_PATH/$NAME-latest.osm.pbf" -mtime -$DAYS) ]; then
+    echo "OSM data exists and is newer than $DAYS days."
 else
-  FILE_BASE="$(basename "$FILE_NAME")"
+  echo "Downloading $1..."
+  wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf || exit 1
+  wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf.md5 || exit 1
+  (cd "$WORK_PATH" && exec md5sum -c "$1-latest.osm.pbf.md5") || exit 1
+  wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1.poly || exit 1
 fi
 
-# Download data
-echo "Downloading $1..."
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME-latest.osm.pbf || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME-latest.osm.pbf.md5 || exit 1
-(cd "$WORK_PATH" && exec md5sum -c "$FILE_BASE-latest.osm.pbf.md5") || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME.poly || exit 1
+echo "Get bounds from command line arguments"
 
 # Bounds
-echo "Buffer Size = $BUFFER_SIZE"
-BBOX=$(perl poly2bb.pl "$WORK_PATH/$FILE_BASE.poly" $BUFFER_SIZE)
-
-MAX_LAT=73
-MIN_LAT=-73
-
-BBOX=(${BBOX//,/ })
-LEFT=${BBOX[1]}
-RIGHT=${BBOX[3]}
-
-if (( ${BBOX[0]%.*} > $MIN_LAT )); then
-  BOTTOM=${BBOX[0]}
-else
-  BOTTOM=$MIN_LAT
-fi
-
-if (( ${BBOX[2]%.*} < $MAX_LAT )); then
-  TOP=${BBOX[2]}
-else
-  TOP=$MAX_LAT
-fi
+LEFT=$3
+BOTTOM=$4
+RIGHT=$5
+TOP=$6
 
 # Start position
-
-CENTER=$(perl poly2center.pl "$WORK_PATH/$NAME.poly")
-CENTER=(${CENTER//,/ })
-LAT=${CENTER[0]}
-LON=${CENTER[1]}
+LON=$7
+LAT=$8
 
 # Fiji crosses 180 longitude, adjust its longitude bounds and center
 if [ "$1" == "australia-oceania/fiji" ]; then
@@ -129,21 +113,33 @@ if [ "$1" == "australia-oceania/fiji" ]; then
   LON=178.0
 fi
 
-echo "BBOX: $LEFT,$BOTTOM to $RIGHT,$TOP"
+echo "BBOX: $LEFT,$BOTTOM to $RIGHT,$TOP Center $LAT,$LON"
 
 # Land
+echo "Run ogr2ogr"
 ogr2ogr -overwrite -progress -skipfailures -clipsrc $LEFT $BOTTOM $RIGHT $TOP "$WORK_PATH/land.shp" "$DATA_PATH/land-polygons-split-4326/land_polygons.shp"
+echo "Run shape2osm"
 python shape2osm.py -l "$WORK_PATH/land" "$WORK_PATH/land.shp"
 
 # Sea
+
 cp sea.osm "$WORK_PATH"
 sed -i "s/\$BOTTOM/$BOTTOM/g" "$WORK_PATH/sea.osm"
 sed -i "s/\$LEFT/$LEFT/g" "$WORK_PATH/sea.osm"
 sed -i "s/\$TOP/$TOP/g" "$WORK_PATH/sea.osm"
 sed -i "s/\$RIGHT/$RIGHT/g" "$WORK_PATH/sea.osm"
 
-# Merge
-CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$FILE_BASE-latest.osm.pbf \
+# Extract OSM features within the bounding box
+echo "Extract OSM features within bounding box"
+CMD="$OSMOSIS_HOME/bin/osmosis --read-pbf $WORK_PATH/$1-latest.osm.pbf \
+                               --bounding-box top=$TOP left=$LEFT bottom=$BOTTOM right=$RIGHT \
+                               --write-pbf $WORK_PATH/$1-clipped.osm.pbf"
+echo $CMD
+$CMD
+
+# Merge extracted features with land and sea polygon data
+echo "Merge clipped OSM features with land and sea polygons"
+CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$1-clipped.osm.pbf \
                                --rx file=$WORK_PATH/sea.osm --s --m"
 for f in $WORK_PATH/land*.osm; do
   CMD="$CMD --rx file=$f --s --m"
@@ -153,39 +149,41 @@ echo $CMD
 $CMD
 
 # Map
+echo "Create Mapsforge map file"
 if [ "$SKIP_MAP_CREATION" != "true" ]; then
   CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/merge.pbf"
   [ $MAP_TRANSFORM_FILE ] && CMD="$CMD --tt file=$MAP_TRANSFORM_FILE"
-  CMD="$CMD --mw file=$WORK_PATH/$NAME.map \
-                 type=$2 \
+  CMD="$CMD --mw file=$WORK_PATH/$2.map \
+                 type=$9 \
                  bbox=$BOTTOM,$LEFT,$TOP,$RIGHT \
                  map-start-position=$LAT,$LON \
                  map-start-zoom=8 \
                  tag-values=$TAG_VALUES \
                  threads=$THREADS \
                  progress-logs=$PROGRESS_LOGS"
-  [ $4 ] && CMD="$CMD preferred-languages=$4"
+  [ $4 ] && CMD="$CMD preferred-languages=$10"
   [ $MAP_TAG_CONF_FILE ] && CMD="$CMD tag-conf-file=$MAP_TAG_CONF_FILE"
   echo $CMD
   $CMD || exit 1
 
   # Check map size
+
   if [ -f "$MAPS_PATH/$NAME.map" ]; then
-    OLD_SIZE=$(wc -c < "$MAPS_PATH/$NAME.map")
-    NEW_SIZE=$(wc -c < "$WORK_PATH/$NAME.map")
+    OLD_SIZE=$(wc -c < "$MAPS_PATH/$2.map")
+    NEW_SIZE=$(wc -c < "$WORK_PATH/$2.map")
     if [ $NEW_SIZE -lt $(($OLD_SIZE * 70 / 100)) ]; then
       echo "$WORK_PATH/$NAME.map creation is significantly smaller."
       exit 1
     fi
   fi
   mv "$WORK_PATH/$NAME.map" "$MAPS_PATH/$NAME.map"
-
 fi
 
 # POI
+
 if [ "$SKIP_POI_CREATION" != "true" ]; then
-  CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$NAME-latest.osm.pbf \
-                                 --pw file=$WORK_PATH/$NAME.poi \
+  CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$1-latest.osm.pbf \
+                                 --pw file=$WORK_PATH/$1.poi \
                                       progress-logs=$PROGRESS_LOGS"
   [ $POI_TAG_CONF_FILE ] && CMD="$CMD tag-conf-file=$POI_TAG_CONF_FILE"
   echo $CMD
@@ -193,4 +191,5 @@ if [ "$SKIP_POI_CREATION" != "true" ]; then
   mv "$WORK_PATH/$NAME.poi" "$POIS_PATH/$NAME.poi"
 fi
 
-rm -rf "$WORK_PATH"
+# Post-process
+#rm -rf "$WORK_PATH"

--- a/bounded-map-creator
+++ b/bounded-map-creator
@@ -11,7 +11,7 @@
 
 # http://wiki.openstreetmap.org/wiki/Osmosis
 
-[ $OSMOSIS_HOME ] || OSMOSIS_HOME="/home/dnesbitt/osmosis"
+[ $OSMOSIS_HOME ] || OSMOSIS_HOME="/$HOME/programs/osmosis"
 [ $DATA_PATH ] || DATA_PATH="./mapsforge/data"
 [ $MAPS_PATH ] || MAPS_PATH="./mapsforge/maps"
 [ $POIS_PATH ] || POIS_PATH="./mapsforge/pois"
@@ -113,7 +113,7 @@ if [ "$1" == "australia-oceania/fiji" ]; then
   LON=178.0
 fi
 
-echo "BBOX: $LEFT,$BOTTOM to $RIGHT,$TOP Center $LAT,$LON"
+echo "BBOX: $LEFT,$BOTTOM to $RIGHT,$TOP Center $LON,$LAT"
 
 # Land
 echo "Run ogr2ogr"

--- a/map-creator
+++ b/map-creator
@@ -82,11 +82,11 @@ echo "Downloading $1..."
 wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf || exit 1
 wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf.md5 || exit 1
 (cd "$WORK_PATH" && exec md5sum -c "$NAME-latest.osm.pbf.md5") || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1ILE_NAME.poly || exit 1
+wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1.poly || exit 1
 
 # Bounds
 echo "Buffer Size = $BUFFER_SIZE"
-BBOX=$(perl poly2bb.pl "$WORK_PATH/$FILE_BASE.poly" $BUFFER_SIZE)
+BBOX=$(perl poly2bb.pl "$WORK_PATH/$NAME.poly" $BUFFER_SIZE)
 
 MAX_LAT=73
 MIN_LAT=-73
@@ -135,7 +135,7 @@ sed -i "s/\$TOP/$TOP/g" "$WORK_PATH/sea.osm"
 sed -i "s/\$RIGHT/$RIGHT/g" "$WORK_PATH/sea.osm"
 
 # Merge
-CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$FILE_BASE-latest.osm.pbf \
+CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$NAME-latest.osm.pbf \
                                --rx file=$WORK_PATH/sea.osm --s --m"
 for f in $WORK_PATH/land*.osm; do
   CMD="$CMD --rx file=$f --s --m"
@@ -149,7 +149,7 @@ if [ "$SKIP_MAP_CREATION" != "true" ]; then
   CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/merge.pbf"
   [ $MAP_TRANSFORM_FILE ] && CMD="$CMD --tt file=$MAP_TRANSFORM_FILE"
   CMD="$CMD --mw file=$WORK_PATH/$NAME.map \
-                 type=$2 \
+                 type=$3 \
                  bbox=$BOTTOM,$LEFT,$TOP,$RIGHT \
                  map-start-position=$LAT,$LON \
                  map-start-zoom=8 \

--- a/map-creator
+++ b/map-creator
@@ -77,20 +77,12 @@ else
   unzip -oq "$DATA_PATH/land-polygons-split-4326.zip" -d "$DATA_PATH"
 fi
 
-#Name override
-if [ "$FILE_NAME" == "" ]; then
-  FILE_NAME=$1
-  FILE_BASE=$NAME
-else
-  FILE_BASE="$(basename "$FILE_NAME")"
-fi
-
 # Download data
 echo "Downloading $1..."
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME-latest.osm.pbf || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME-latest.osm.pbf.md5 || exit 1
-(cd "$WORK_PATH" && exec md5sum -c "$FILE_BASE-latest.osm.pbf.md5") || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME.poly || exit 1
+wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf || exit 1
+wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf.md5 || exit 1
+(cd "$WORK_PATH" && exec md5sum -c "$NAME-latest.osm.pbf.md5") || exit 1
+wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1ILE_NAME.poly || exit 1
 
 # Bounds
 echo "Buffer Size = $BUFFER_SIZE"

--- a/poly2bb.pl
+++ b/poly2bb.pl
@@ -11,7 +11,9 @@ $maxy = -360;
 $minx = 360;
 $miny = 360;
 
-while(<>)
+open(f, $ARGV[0]);
+
+while(<f>)
 {
    if (/^\s+([0-9.E+-]+)\s+([0-9.E+-]+)\s*$/)
    {
@@ -22,8 +24,9 @@ while(<>)
        $miny = $y if ($y<$miny);
    }
 }
+close($ARGV[0]);
 
-$buffer = 0.1;
+$buffer = $ARGV[1];
 $miny = $miny - $buffer;
 $miny = $miny < -90 ? -90 : $miny;
 $minx = $minx - $buffer;

--- a/single-map-creator
+++ b/single-map-creator
@@ -11,20 +11,24 @@
 
 # http://wiki.openstreetmap.org/wiki/Osmosis
 
-[ $OSMOSIS_HOME ] || OSMOSIS_HOME="$HOME/programs/osmosis"
-[ $DATA_PATH ] || DATA_PATH="$HOME/mapsforge/data"
-[ $MAPS_PATH ] || MAPS_PATH="$HOME/mapsforge/maps"
-[ $POIS_PATH ] || POIS_PATH="$HOME/mapsforge/pois"
+[ $OSMOSIS_HOME ] || OSMOSIS_HOME="/home/dnesbitt/osmosis"
+[ $DATA_PATH ] || DATA_PATH="./mapsforge/data"
+[ $MAPS_PATH ] || MAPS_PATH="./mapsforge/maps"
+[ $POIS_PATH ] || POIS_PATH="./mapsforge/pois"
 [ $PROGRESS_LOGS ] || PROGRESS_LOGS="true"
 [ $TAG_VALUES ] || TAG_VALUES="false"
-[ $THREADS ] || THREADS="1"
-[ $DAYS ] || DAYS="30"
+[ $THREADS ] || THREADS="12"
+[ $DAYS ] || DAYS="7"
+[ $MAP_TAG_CONF_FILE ] || MAP_TAG_CONF_FILE="./tag-mapping.xml"
+[ $SKIP_MAP_CREATION ] || SKIP_MAP_CREATION="false"
+[ $SKIP_POI_CREATION ] || SKIP_POI_CREATION="true"
 
 # =========== DO NOT CHANGE AFTER THIS LINE. ===========================
 # Below here is regular code, part of the file. This is not designed to
 # be modified by users.
 # ======================================================================
 
+# Added a configurable buffer size as an argument
 if [ $# -lt 3 ]; then
   echo "Usage: $0 continent/country[/region] buffer_size ram|hd [lang,...]"
   echo "Example: $0 europe/germany/berlin 0.1 ram en,de,fr,es"
@@ -40,13 +44,14 @@ BUFFER_SIZE="$2"
 if [ "$TAG_VALUES" = "true" ]; then
   MAPS_PATH="$MAPS_PATH/v5"
 else
-  [ $3 ] && MAPS_PATH="$MAPS_PATH/v4" || MAPS_PATH="$MAPS_PATH/v3"
+  MAPS_PATH="$MAPS_PATH/v4"
 fi
 MAPS_PATH="$(dirname "$MAPS_PATH/$1")"
 
 POIS_PATH="$(dirname "$POIS_PATH/$1")"
 
 # Check map date
+
 if [ -f "$MAPS_PATH/$NAME.map" ]; then
   if [ $(find "$MAPS_PATH/$NAME.map" -mtime -$DAYS) ]; then
     echo "$MAPS_PATH/$NAME.map exists and is newer than $DAYS days."
@@ -55,7 +60,8 @@ if [ -f "$MAPS_PATH/$NAME.map" ]; then
 fi
 
 # Pre-process
-rm -rf "$WORK_PATH"
+
+#rm -rf "$WORK_PATH"
 mkdir -p "$WORK_PATH"
 
 if [ "$SKIP_MAP_CREATION" != "true" ]; then
@@ -67,6 +73,7 @@ if [ "$SKIP_POI_CREATION" != "true" ]; then
 fi
 
 # Download land
+
 if [ -f "$DATA_PATH/land-polygons-split-4326/land_polygons.shp" ] && [ $(find "$DATA_PATH/land-polygons-split-4326/land_polygons.shp" -mtime -$DAYS) ]; then
   echo "Land polygons exist and are newer than $DAYS days."
 else
@@ -77,43 +84,27 @@ else
   unzip -oq "$DATA_PATH/land-polygons-split-4326.zip" -d "$DATA_PATH"
 fi
 
-#Name override
-if [ "$FILE_NAME" == "" ]; then
-  FILE_NAME=$1
-  FILE_BASE=$NAME
-else
-  FILE_BASE="$(basename "$FILE_NAME")"
-fi
-
 # Download data
-echo "Downloading $1..."
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME-latest.osm.pbf || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME-latest.osm.pbf.md5 || exit 1
-(cd "$WORK_PATH" && exec md5sum -c "$FILE_BASE-latest.osm.pbf.md5") || exit 1
-wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$FILE_NAME.poly || exit 1
+echo "Check if $WORK_PATH/$NAME-latest.osm.pbf exists"
+if [ -f "$WORK_PATH/$NAME-latest.osm.pbf" ] && [ $(find "$WORK_PATH/$NAME-latest.osm.pbf" -mtime -$DAYS) ]; then
+    echo "OSM data exists and is newer than $DAYS days."
+else
+  echo "Downloading $1..."
+  wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf || exit 1
+  wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1-latest.osm.pbf.md5 || exit 1
+  (cd "$WORK_PATH" && exec md5sum -c "$NAME-latest.osm.pbf.md5") || exit 1
+  wget -nv -N -P "$WORK_PATH" https://download.geofabrik.de/$1.poly || exit 1
+fi
 
 # Bounds
+
 echo "Buffer Size = $BUFFER_SIZE"
-BBOX=$(perl poly2bb.pl "$WORK_PATH/$FILE_BASE.poly" $BUFFER_SIZE)
-
-MAX_LAT=73
-MIN_LAT=-73
-
+BBOX=$(perl poly2bb.pl "$WORK_PATH/$NAME.poly" $BUFFER_SIZE)
 BBOX=(${BBOX//,/ })
+BOTTOM=${BBOX[0]}
 LEFT=${BBOX[1]}
+TOP=${BBOX[2]}
 RIGHT=${BBOX[3]}
-
-if (( ${BBOX[0]%.*} > $MIN_LAT )); then
-  BOTTOM=${BBOX[0]}
-else
-  BOTTOM=$MIN_LAT
-fi
-
-if (( ${BBOX[2]%.*} < $MAX_LAT )); then
-  TOP=${BBOX[2]}
-else
-  TOP=$MAX_LAT
-fi
 
 # Start position
 
@@ -132,10 +123,13 @@ fi
 echo "BBOX: $LEFT,$BOTTOM to $RIGHT,$TOP"
 
 # Land
+echo "Run ogr2ogr"
 ogr2ogr -overwrite -progress -skipfailures -clipsrc $LEFT $BOTTOM $RIGHT $TOP "$WORK_PATH/land.shp" "$DATA_PATH/land-polygons-split-4326/land_polygons.shp"
+echo "Run shape2osm"
 python shape2osm.py -l "$WORK_PATH/land" "$WORK_PATH/land.shp"
 
 # Sea
+
 cp sea.osm "$WORK_PATH"
 sed -i "s/\$BOTTOM/$BOTTOM/g" "$WORK_PATH/sea.osm"
 sed -i "s/\$LEFT/$LEFT/g" "$WORK_PATH/sea.osm"
@@ -143,7 +137,8 @@ sed -i "s/\$TOP/$TOP/g" "$WORK_PATH/sea.osm"
 sed -i "s/\$RIGHT/$RIGHT/g" "$WORK_PATH/sea.osm"
 
 # Merge
-CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$FILE_BASE-latest.osm.pbf \
+
+CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$NAME-latest.osm.pbf \
                                --rx file=$WORK_PATH/sea.osm --s --m"
 for f in $WORK_PATH/land*.osm; do
   CMD="$CMD --rx file=$f --s --m"
@@ -153,11 +148,12 @@ echo $CMD
 $CMD
 
 # Map
+
 if [ "$SKIP_MAP_CREATION" != "true" ]; then
   CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/merge.pbf"
   [ $MAP_TRANSFORM_FILE ] && CMD="$CMD --tt file=$MAP_TRANSFORM_FILE"
   CMD="$CMD --mw file=$WORK_PATH/$NAME.map \
-                 type=$2 \
+                 type=$3 \
                  bbox=$BOTTOM,$LEFT,$TOP,$RIGHT \
                  map-start-position=$LAT,$LON \
                  map-start-zoom=8 \
@@ -170,6 +166,7 @@ if [ "$SKIP_MAP_CREATION" != "true" ]; then
   $CMD || exit 1
 
   # Check map size
+
   if [ -f "$MAPS_PATH/$NAME.map" ]; then
     OLD_SIZE=$(wc -c < "$MAPS_PATH/$NAME.map")
     NEW_SIZE=$(wc -c < "$WORK_PATH/$NAME.map")
@@ -179,10 +176,10 @@ if [ "$SKIP_MAP_CREATION" != "true" ]; then
     fi
   fi
   mv "$WORK_PATH/$NAME.map" "$MAPS_PATH/$NAME.map"
-
 fi
 
 # POI
+
 if [ "$SKIP_POI_CREATION" != "true" ]; then
   CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$WORK_PATH/$NAME-latest.osm.pbf \
                                  --pw file=$WORK_PATH/$NAME.poi \
@@ -193,4 +190,5 @@ if [ "$SKIP_POI_CREATION" != "true" ]; then
   mv "$WORK_PATH/$NAME.poi" "$POIS_PATH/$NAME.poi"
 fi
 
-rm -rf "$WORK_PATH"
+# Post-process
+#rm -rf "$WORK_PATH"

--- a/single-map-creator
+++ b/single-map-creator
@@ -11,13 +11,13 @@
 
 # http://wiki.openstreetmap.org/wiki/Osmosis
 
-[ $OSMOSIS_HOME ] || OSMOSIS_HOME="/home/dnesbitt/osmosis"
-[ $DATA_PATH ] || DATA_PATH="./mapsforge/data"
-[ $MAPS_PATH ] || MAPS_PATH="./mapsforge/maps"
-[ $POIS_PATH ] || POIS_PATH="./mapsforge/pois"
+[ $OSMOSIS_HOME ] || OSMOSIS_HOME="$HOME/programs/osmosis"
+[ $DATA_PATH ] || DATA_PATH="$HOME/mapsforge/data"
+[ $MAPS_PATH ] || MAPS_PATH="$HOME/mapsforge/maps"
+[ $POIS_PATH ] || POIS_PATH="$HOME/mapsforge/pois"
 [ $PROGRESS_LOGS ] || PROGRESS_LOGS="true"
 [ $TAG_VALUES ] || TAG_VALUES="false"
-[ $THREADS ] || THREADS="12"
+[ $THREADS ] || THREADS="8"
 [ $DAYS ] || DAYS="7"
 [ $MAP_TAG_CONF_FILE ] || MAP_TAG_CONF_FILE="./tag-mapping.xml"
 [ $SKIP_MAP_CREATION ] || SKIP_MAP_CREATION="false"

--- a/tag-mapping.xml
+++ b/tag-mapping.xml
@@ -1,0 +1,519 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tag-mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" default-zoom-appear="16"
+    profile-name="default-profile" xmlns="http://mapsforge.org/tag-mapping"
+    xsi:schemaLocation="http://mapsforge.org/tag-mapping https://raw.githubusercontent.com/mapsforge/mapsforge/master/resources/tag-mapping.xsd">
+
+    <!-- ************* POIS *************** -->
+
+    <!-- HIGHWAY TAGS -->
+    <!-- <pois>
+        <osm-tag key="highway" value="bus_stop" zoom-appear="17" />
+        <osm-tag key="highway" value="mini_roundabout" zoom-appear="17" />
+        <osm-tag key="highway" value="traffic_signals" zoom-appear="17" />
+        <osm-tag key="highway" value="turning_circle" zoom-appear="15" />
+        <osm-tag key="highway" value="street_lamp" zoom-appear="17" />
+    </pois> -->
+
+    <!-- PUBLIC AMENITIES -->
+    <pois>
+        <osm-tag key="amenity" value="atm" zoom-appear="15" />
+        <osm-tag key="amenity" value="bank" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="bar" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="bench" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="bicycle_rental" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="bus_station" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="cafe" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="cinema" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="drinking_water" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="fast_food" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="fountain" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="fire_station" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="fuel" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="grave_yard" zoom-appear="15" />
+        <osm-tag key="amenity" value="hospital" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="kindergarten" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="library" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="parking" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="pharmacy" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="place_of_worship" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="police" zoom-appear="15" />
+        <osm-tag key="amenity" value="post_box" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="post_office" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="pub" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="recycling" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="restaurant" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="school" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="shelter" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="telephone" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="theatre" zoom-appear="15" /> -->
+        <!-- <osm-tag key="amenity" value="townhall" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="toilets" zoom-appear="15" />
+        <osm-tag key="amenity" value="university" zoom-appear="15" />
+
+        <osm-tag key="emergency" value="phone" zoom-appear="16" />
+
+        <osm-tag key="leisure" value="playground" zoom-appear="17" />
+        <osm-tag key="leisure" value="slipway" zoom-appear="17" />
+
+        <!-- <osm-tag key="religion" renderable="false" value="buddhist" />
+        <osm-tag key="religion" renderable="false" value="christian" />
+        <osm-tag key="religion" renderable="false" value="hindu" />
+        <osm-tag key="religion" renderable="false" value="jewish" />
+        <osm-tag key="religion" renderable="false" value="muslim" />
+        <osm-tag key="religion" renderable="false" value="shinto" /> -->
+
+        <osm-tag key="shop" value="bakery" zoom-appear="15" />
+        <osm-tag key="shop" value="bicycle" zoom-appear="15" />
+        <osm-tag key="shop" value="convenience" zoom-appear="15" />
+        <osm-tag key="shop" value="hairdresser" zoom-appear="15" />
+        <osm-tag key="shop" value="laundry" zoom-appear="15" />
+        <osm-tag key="shop" value="mall" zoom-appear="15" />
+        <osm-tag key="shop" value="organic" zoom-appear="15" />
+        <osm-tag key="shop" value="supermarket" zoom-appear="15" />
+    </pois>
+
+    <!-- PUBLIC TRANSPORT TAGS -->
+    <!-- <pois>
+        <osm-tag key="railway" value="halt" zoom-appear="16" />
+        <osm-tag key="railway" value="level_crossing" zoom-appear="16" />
+        <osm-tag key="railway" value="station" zoom-appear="14" />
+        <osm-tag key="railway" value="tram_stop" zoom-appear="16" />
+
+        <osm-tag key="station" value="light_rail" zoom-appear="15">
+            <zoom-override key="railway" value="station" />
+        </osm-tag>
+        <osm-tag key="station" value="subway" zoom-appear="15">
+            <zoom-override key="railway" value="station" />
+        </osm-tag>
+    </pois> -->
+
+    <!-- TOURISM TAGS -->
+    <pois>
+        <!-- <osm-tag key="tourism" value="alpine_hut" zoom-appear="15" /> -->
+        <!-- <osm-tag key="tourism" value="artwork" zoom-appear="17" /> -->
+        <!-- <osm-tag key="tourism" value="attraction" zoom-appear="17" /> -->
+        <osm-tag key="tourism" value="camp_site" zoom-appear="17" />
+        <!-- <osm-tag key="tourism" value="hostel" zoom-appear="17" /> -->
+        <!-- <osm-tag key="tourism" value="hotel" zoom-appear="17" /> -->
+        <!-- <osm-tag key="tourism" value="information" zoom-appear="17" /> -->
+        <!-- <osm-tag key="tourism" value="museum" zoom-appear="17" /> -->
+        <osm-tag key="tourism" value="picnic_site" zoom-appear="15" />
+        <osm-tag key="tourism" value="viewpoint" zoom-appear="15" />
+
+        <!-- <osm-tag key="historic" value="memorial" zoom-appear="17" /> -->
+        <!-- <osm-tag key="historic" value="monument" zoom-appear="17" /> -->
+    </pois>
+
+    <!-- PLACES TAGS -->
+    <pois>
+        <osm-tag key="place" value="city" zoom-appear="6" />
+        <osm-tag key="place" value="country" zoom-appear="3" />
+        <osm-tag key="place" value="hamlet" zoom-appear="13" />
+        <osm-tag key="place" value="island" zoom-appear="12" />
+        <osm-tag key="place" value="locality" zoom-appear="13" />
+        <osm-tag key="place" value="suburb" zoom-appear="12" />
+        <osm-tag key="place" value="town" zoom-appear="9" />
+        <osm-tag key="place" value="village" zoom-appear="12" />
+    </pois>
+
+    <!-- NATURAL TAGS -->
+    <!-- <pois>
+        <osm-tag key="leaf_type" renderable="false" value="broadleaved" />
+        <osm-tag key="leaf_type" renderable="false" value="needleleaved" />
+        <osm-tag key="leaf_type" renderable="false" value="leafless" />
+
+        <osm-tag key="natural" value="cave_entrance" zoom-appear="14" />
+        <osm-tag key="natural" value="peak" zoom-appear="12" />
+        <osm-tag key="natural" value="spring" zoom-appear="17" />
+        <osm-tag key="natural" value="tree" zoom-appear="17" />
+        <osm-tag key="natural" value="volcano" zoom-appear="12" />
+    </pois> -->
+
+    <!-- OTHER POIS -->
+    <!-- <pois>
+        <osm-tag key="barrier" value="bollard" zoom-appear="17" />
+        <osm-tag key="barrier" value="cycle_barrier" zoom-appear="17" />
+        <osm-tag key="barrier" value="gate" zoom-appear="17" />
+        <osm-tag key="barrier" value="lift_gate" zoom-appear="17" />
+        <osm-tag key="barrier" value="toll_booth" zoom-appear="15" />
+
+        <osm-tag key="man_made" value="lighthouse" zoom-appear="17" />
+        <osm-tag key="man_made" value="surveillance" zoom-appear="17" />
+        <osm-tag key="man_made" value="tower" zoom-appear="17" />
+        <osm-tag key="man_made" value="windmill" zoom-appear="17" />
+
+        <osm-tag key="power" value="generator" zoom-appear="17" />
+        <osm-tag key="power" value="tower" zoom-appear="17" />
+    </pois> -->
+
+    <!-- AIRPORT TAGS -->
+    <pois>
+        <osm-tag key="aeroway" value="aerodrome" zoom-appear="13" />
+        <osm-tag key="aeroway" value="airport" zoom-appear="13" />
+        <osm-tag key="aeroway" value="gate" zoom-appear="17" />
+        <osm-tag key="aeroway" value="helipad" zoom-appear="17" />
+    </pois>
+
+
+    <!-- ************* WAYS *************** -->
+
+    <!-- HIGHWAY TAGS -->
+    <ways>
+        <osm-tag key="highway" value="bridleway" zoom-appear="13" />
+        <!-- <osm-tag key="highway" value="bus_guideway" zoom-appear="13" /> -->
+        <!-- <osm-tag key="highway" value="byway" zoom-appear="13" /> -->
+        <!-- <osm-tag key="highway" value="construction" zoom-appear="13" /> -->
+        <osm-tag key="highway" value="cycleway" zoom-appear="13" />
+        <osm-tag key="highway" value="footway" zoom-appear="14" />
+        <osm-tag key="highway" value="living_street" zoom-appear="13" />
+        <osm-tag key="highway" value="motorway" zoom-appear="6" />
+        <osm-tag key="highway" value="motorway_link" zoom-appear="6" />
+        <osm-tag key="highway" value="path" zoom-appear="14" />
+        <osm-tag key="highway" value="pedestrian" zoom-appear="14" />
+        <osm-tag key="highway" value="primary" zoom-appear="8" />
+        <osm-tag key="highway" value="primary_link" zoom-appear="8" />
+        <osm-tag key="highway" value="raceway" zoom-appear="12" />
+        <osm-tag key="highway" value="residential" zoom-appear="12" />
+        <osm-tag key="highway" value="road" zoom-appear="12" />
+        <osm-tag key="highway" value="secondary" zoom-appear="12" />
+        <osm-tag key="highway" value="secondary_link" zoom-appear="12" />
+        <osm-tag key="highway" value="service" zoom-appear="14" />
+        <!-- <osm-tag key="highway" value="services" zoom-appear="14" /> -->
+        <!-- <osm-tag key="highway" value="steps" zoom-appear="16" /> -->
+        <osm-tag key="highway" value="tertiary" zoom-appear="12" />
+        <osm-tag key="highway" value="tertiary_link" zoom-appear="12" />
+        <osm-tag key="highway" value="track" zoom-appear="13" />
+        <osm-tag key="highway" value="trunk" zoom-appear="6" />
+        <osm-tag key="highway" value="trunk_link" zoom-appear="6" />
+        <osm-tag key="highway" value="unclassified" zoom-appear="12" />
+    </ways>
+
+    <!-- CYCLEWAY TAGS -->
+    <ways>
+        <osm-tag key="cycleway" value="lane" zoom-appear="8" />
+        <osm-tag key="cycleway" value="opposite_lane" zoom-appear="8" />
+        <osm-tag key="cycleway" value="opposite" zoom-appear="8" />
+        <osm-tag key="cycleway" value="shared_lane" zoom-appear="8" />
+        <osm-tag key="cycleway" value="share_busway" zoom-appear="8" />
+        <osm-tag key="cycleway" value="shared" zoom-appear="8" />
+        <osm-tag key="cycleway" value="track" zoom-appear="8" />
+        <osm-tag key="cycleway" value="opposite_track" zoom-appear="8" />
+        <osm-tag key="cycleway" value="cyclestreet" zoom-appear="8" />
+    </ways>
+    <ways>
+        <osm-tag key="route" value="bicycle" zoom-appear="8" />
+    </ways>
+    <ways>
+        <osm-tag key="bicycle" value="designated" zoom-appear="8" />
+        <osm-tag key="bicycle" value="yes" zoom-appear="8" />
+    </ways>
+
+    <!-- NATURAL / WATERWAY TAGS -->
+    <ways>
+        <!-- <osm-tag key="leaf_type" renderable="false" value="broadleaved" />
+        <osm-tag key="leaf_type" renderable="false" value="needleleaved" />
+        <osm-tag key="leaf_type" renderable="false" value="leafless" />
+
+        <osm-tag key="lock" value="yes" zoom-appear="14" /> -->
+
+        <!-- mapsforge artificial tags for land/sea areas, do not remove -->
+        <osm-tag key="natural" value="sea" zoom-appear="0" />
+        <osm-tag key="natural" value="nosea" zoom-appear="0" />
+
+        <osm-tag key="natural" value="beach" zoom-appear="10" />
+        <!-- <osm-tag key="natural" value="coastline" zoom-appear="0" /> -->
+        <!-- <osm-tag key="natural" value="fell" zoom-appear="10" /> -->
+        <!-- <osm-tag enabled="false" key="natural" value="glacier" zoom-appear="8" /> -->
+        <osm-tag key="natural" value="grassland" zoom-appear="10" />
+        <!-- <osm-tag key="natural" value="heath" zoom-appear="10" /> -->
+        <!-- <osm-tag key="natural" value="land" zoom-appear="8" /> -->
+        <!-- <osm-tag key="natural" value="marsh" zoom-appear="12" /> -->
+        <osm-tag key="natural" value="scrub" zoom-appear="10" />
+        <osm-tag key="natural" value="scree" zoom-appear="10" />
+        <osm-tag key="natural" value="water" zoom-appear="8" />
+        <!-- <osm-tag key="natural" value="wetland" zoom-appear="12" /> -->
+        <osm-tag key="natural" value="wood" zoom-appear="8" />
+
+        <osm-tag key="waterway" value="canal" zoom-appear="10" />
+        <!-- <osm-tag key="waterway" value="dam" zoom-appear="10" /> -->
+        <osm-tag key="waterway" value="drain" zoom-appear="13" />
+        <osm-tag key="waterway" value="river" zoom-appear="8" />
+        <osm-tag key="waterway" value="riverbank" zoom-appear="8" />
+        <osm-tag key="waterway" value="stream" zoom-appear="13" />
+    </ways>
+
+    <!-- LANDUSE TAGS -->
+    <ways>
+        <!-- <osm-tag key="landuse" value="allotments" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="basin" zoom-appear="12" /> -->
+        <!-- <osm-tag key="landuse" value="brownfield" zoom-appear="10" /> -->
+        <osm-tag key="landuse" value="cemetery" zoom-appear="10" />
+        <!-- <osm-tag key="landuse" value="commercial" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="construction" zoom-appear="12" /> -->
+        <osm-tag key="landuse" value="farm" zoom-appear="12" />
+        <osm-tag key="landuse" value="farmland" zoom-appear="12" />
+        <!-- <osm-tag key="landuse" value="factory" zoom-appear="12" /> -->
+        <osm-tag key="landuse" value="farmyard" zoom-appear="12" />
+        <osm-tag key="landuse" value="forest" zoom-appear="8" />
+        <osm-tag key="landuse" value="grass" zoom-appear="12" />
+        <!-- <osm-tag key="landuse" value="greenfield" zoom-appear="12" /> -->
+        <!-- <osm-tag key="landuse" value="industrial" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="landfill" zoom-appear="12" /> -->
+        <osm-tag key="landuse" value="meadow" zoom-appear="12" />
+        <!-- <osm-tag key="landuse" value="military" zoom-appear="10" /> -->
+        <osm-tag key="landuse" value="orchard" zoom-appear="12" />
+        <!-- <osm-tag key="landuse" value="quarry" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="railway" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="recreation_ground" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="reservoir" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="residential" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="retail" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="village_green" zoom-appear="10" /> -->
+        <!-- <osm-tag key="landuse" value="vineyard" zoom-appear="12" /> -->
+        <osm-tag key="landuse" value="wood" zoom-appear="8" />
+    </ways>
+
+    <!-- LEISURE/SPORT TAGS -->
+    <ways>
+        <osm-tag key="leisure" value="common" zoom-appear="12" />
+        <!-- <osm-tag key="leisure" value="dog_park" zoom-appear="12" /> -->
+        <osm-tag key="leisure" value="garden" zoom-appear="12" />
+        <osm-tag key="leisure" value="golf_course" zoom-appear="12" />
+        <osm-tag key="leisure" value="nature_reserve" zoom-appear="12" />
+        <osm-tag key="leisure" value="park" zoom-appear="10" />
+        <osm-tag key="leisure" value="pitch" zoom-appear="12" />
+        <!-- <osm-tag key="leisure" value="playground" zoom-appear="12" /> -->
+        <!-- <osm-tag key="leisure" value="sports_centre" zoom-appear="12" /> -->
+        <!-- <osm-tag key="leisure" value="stadium" zoom-appear="10" /> -->
+        <!-- <osm-tag key="leisure" value="swimming_pool" zoom-appear="14" /> -->
+        <!-- <osm-tag key="leisure" value="track" zoom-appear="12" /> -->
+        <!-- <osm-tag key="leisure" value="water_park" zoom-appear="12" /> -->
+
+        <!-- <osm-tag key="sport" value="golf" zoom-appear="12" />
+        <osm-tag key="sport" value="soccer" zoom-appear="12" />
+        <osm-tag key="sport" value="swimming" zoom-appear="12" />
+        <osm-tag key="sport" value="tennis" zoom-appear="12" />
+        <osm-tag key="sport" value="baseball" zoom-appear="12" />
+        <osm-tag key="sport" value="basketball" zoom-appear="12" />
+        <osm-tag key="sport" value="volleyball" zoom-appear="12" />
+        <osm-tag key="sport" value="skiing" zoom-appear="12" />
+        <osm-tag key="sport" value="shooting" zoom-appear="12" />
+        <osm-tag key="sport" value="cricket" zoom-appear="12" />
+        <osm-tag key="sport" value="boules" zoom-appear="12" />
+        <osm-tag key="sport" value="football" zoom-appear="12" />
+        <osm-tag key="sport" value="skating" zoom-appear="12" />
+        <osm-tag key="sport" value="climbing" zoom-appear="12" />
+        <osm-tag key="sport" value="equestrian" zoom-appear="12" />
+        <osm-tag key="sport" value="bowls" zoom-appear="12" />
+        <osm-tag key="sport" value="multi" zoom-appear="12" /> -->
+
+    </ways>
+
+    <!-- PUBLIC AMENITIES -->
+    <ways>
+        <osm-tag key="amenity" value="college" zoom-appear="13" />
+        <!-- <osm-tag key="amenity" value="embassy" zoom-appear="13" /> -->
+        <!-- <osm-tag key="amenity" value="fountain" zoom-appear="16" /> -->
+        <!-- <osm-tag key="amenity" value="grave_yard" zoom-appear="14" /> -->
+        <osm-tag key="amenity" value="hospital" zoom-appear="13" />
+        <osm-tag key="amenity" value="parking" zoom-appear="14" />
+        <!-- <osm-tag key="amenity" value="place_of_worship" zoom-appear="14" /> -->
+        <osm-tag key="amenity" value="school" zoom-appear="14" />
+        <!-- <osm-tag key="amenity" value="swimming_pool" zoom-appear="14" /> -->
+        <!-- <osm-tag key="amenity" value="theatre" zoom-appear="14" /> -->
+        <!-- <osm-tag key="amenity" value="toilets" zoom-appear="17" /> -->
+        <osm-tag key="amenity" value="university" zoom-appear="13" />
+
+        <!-- <osm-tag key="religion" renderable="false" value="buddhist" />
+        <osm-tag key="religion" renderable="false" value="christian" />
+        <osm-tag key="religion" renderable="false" value="hindu" />
+        <osm-tag key="religion" renderable="false" value="jewish" />
+        <osm-tag key="religion" renderable="false" value="muslim" />
+        <osm-tag key="religion" renderable="false" value="shinto" /> -->
+
+        <!-- <osm-tag key="tourism" value="attraction" zoom-appear="14" />
+        <osm-tag key="tourism" value="hostel" zoom-appear="15" />
+        <osm-tag key="tourism" value="zoo" zoom-appear="12" /> -->
+    </ways>
+
+    <!-- PUBLIC TRANSPORT -->
+    <ways>
+        <osm-tag key="railway" value="disused" zoom-appear="15" />
+        <osm-tag key="railway" value="funicular" zoom-appear="12" />
+        <osm-tag key="railway" value="light_rail" zoom-appear="12" />
+        <osm-tag key="railway" value="miniature" zoom-appear="14" />
+        <osm-tag key="railway" value="monorail" zoom-appear="14" />
+        <osm-tag key="railway" value="narrow_gauge" zoom-appear="14" />
+        <osm-tag key="railway" value="platform" zoom-appear="14" />
+        <osm-tag key="railway" value="preserved" zoom-appear="14" />
+        <osm-tag key="railway" value="rail" zoom-appear="10" />
+        <osm-tag key="railway" value="station" zoom-appear="14" />
+        <osm-tag key="railway" value="subway" zoom-appear="15" />
+        <osm-tag key="railway" value="tram" zoom-appear="15" />
+        <!-- <osm-tag key="route" value="ferry" zoom-appear="12" /> -->
+    </ways>
+
+    <!-- BUILDINGS -->
+    <ways>
+        <osm-tag key="building" label-position="true" value="apartment" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="apartments" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="barn" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="block" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="building" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="cabin" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="castle" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="cathedral" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="chapel" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="church" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="civic" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="commercial" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="detached" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="garage" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="garages" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="embassy" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="factory" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="farm" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="farm_auxiliary" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="government" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="greenhouse" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="gym" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="hangar" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="hotel" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="hospital" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="house" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="hut" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="industrial" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="library" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="manufacture" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="monastery" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="mosque" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="museum" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="office" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="public" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="residential" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="Residential" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="retail" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="roof" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="ruins" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="school" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="service" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="semidetached_house" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="shed" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="shelter" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="shop" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="sports" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="supermarket" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="terrace" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="transportation" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="train_station" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="university" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="wall" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="warehouse" zoom-appear="17" />
+        <osm-tag key="building" label-position="true" value="yes" zoom-appear="17" />
+    </ways>
+
+    <!-- ADMINISTRATIVE BOUNDARIES -->
+    <ways>
+
+        <osm-tag force-polygon-line="true" key="admin_level" value="1" zoom-appear="4">
+            <zoom-override key="boundary" value="administrative" />
+        </osm-tag>
+        <osm-tag force-polygon-line="true" key="admin_level" value="2" zoom-appear="4">
+            <zoom-override key="boundary" value="administrative" />
+        </osm-tag>
+        <osm-tag force-polygon-line="true" key="admin_level" value="3" zoom-appear="4">
+            <zoom-override key="boundary" value="administrative" />
+        </osm-tag>
+        <osm-tag force-polygon-line="true" key="admin_level" value="4" zoom-appear="6">
+            <zoom-override key="boundary" value="administrative" />
+        </osm-tag>
+        <osm-tag force-polygon-line="true" key="admin_level" value="5" zoom-appear="6">
+            <zoom-override key="boundary" value="administrative" />
+        </osm-tag>
+        <osm-tag force-polygon-line="true" key="admin_level" value="6" zoom-appear="6">
+            <zoom-override key="boundary" value="administrative" />
+        </osm-tag>
+        <!-- <osm-tag key="admin_level" value="6" force-polygon-line="true" zoom-appear="15" /> <osm-tag key="admin_level" value="8"
+            force-polygon-line="true" zoom-appear="16" /> <osm-tag key="admin_level" value="9" force-polygon-line="true" zoom-appear="16"
+            /> <osm-tag key="admin_level" value="10" force-polygon-line="true" zoom-appear="16" /> -->
+    </ways>
+
+    <!-- AIRPORT TAGS -->
+    <ways>
+        <osm-tag key="aeroway" value="aerodrome" zoom-appear="13" />
+        <osm-tag key="aeroway" value="apron" zoom-appear="13" />
+        <osm-tag key="aeroway" value="helipad" zoom-appear="17" />
+        <osm-tag key="aeroway" value="runway" zoom-appear="10" />
+        <osm-tag key="aeroway" value="taxiway" zoom-appear="10" />
+        <osm-tag key="aeroway" value="terminal" zoom-appear="15" />
+    </ways>
+
+    <!-- SKI SLOPES TAGS -->
+    <ways>
+        <osm-tag key="piste:type" value="downhill" zoom-appear="13" />
+        <osm-tag key="piste:type" value="nordic" zoom-appear="13" />
+        <osm-tag key="piste:type" value="sled" zoom-appear="13" />
+        <osm-tag key="aerialway" value="cable_car" zoom-appear="13" />
+        <osm-tag key="aerialway" value="chair_lift" zoom-appear="13" />
+        <osm-tag key="aerialway" value="drag_lift" zoom-appear="13" />
+        <osm-tag key="aerialway" value="gondola" zoom-appear="13" />
+        <osm-tag key="aerialway" value="magic_carpet" zoom-appear="13" />
+        <osm-tag key="aerialway" value="mixed_lift" zoom-appear="13" />
+        <osm-tag key="aerialway" value="rope_tow" zoom-appear="13" />
+    </ways>
+
+    <!-- OTHER TAGS -->
+    <ways>
+        <!-- <osm-tag key="barrier" value="city_wall" zoom-appear="14" /> -->
+        <!-- <osm-tag key="barrier" value="fence" zoom-appear="14" /> -->
+        <!-- <osm-tag key="barrier" value="retaining_wall" zoom-appear="16" /> -->
+        <!-- <osm-tag key="barrier" value="wall" zoom-appear="16" /> -->
+
+        <!-- <osm-tag force-polygon-line="true" key="boundary" value="administrative" zoom-appear="0" /> -->
+        <!-- <osm-tag key="boundary" value="national_park" zoom-appear="12" /> -->
+
+        <!-- <osm-tag key="historic" value="ruins" zoom-appear="17" /> -->
+        <!-- <osm-tag key="historic" value="castle" zoom-appear="15" /> -->
+
+        <!-- <osm-tag key="man_made" value="pier" zoom-appear="15" /> -->
+
+        <!-- <osm-tag key="military" value="airfield" zoom-appear="12" /> -->
+        <!-- <osm-tag key="military" value="barracks" zoom-appear="12" /> -->
+        <!-- <osm-tag key="military" value="naval_base" zoom-appear="12" /> -->
+
+        <osm-tag key="place" value="locality" zoom-appear="17" />
+
+        <!-- <osm-tag key="area" value="yes" zoom-appear="12" /> -->
+    </ways>
+
+    <!-- NOT TO RENDER -->
+    <ways>
+        <osm-tag key="id" renderable="false" value="%f" />
+
+        <osm-tag key="access" renderable="false" value="destination" />
+        <osm-tag key="access" renderable="false" value="private" />
+
+        <osm-tag key="bridge" renderable="false" value="yes" />
+
+        <osm-tag equivalent-values="1,true" key="oneway" renderable="false" value="yes" />
+        <osm-tag key="oneway" renderable="false" value="-1" />
+        <osm-tag equivalent-values="0,false" key="oneway" renderable="false" value="no" />
+
+        <osm-tag key="piste:difficulty" renderable="false" value="novice" />
+        <osm-tag key="piste:difficulty" renderable="false" value="easy" />
+        <osm-tag key="piste:difficulty" renderable="false" value="intermediate" />
+        <osm-tag key="piste:difficulty" renderable="false" value="advanced" />
+        <osm-tag key="piste:difficulty" renderable="false" value="expert" />
+        <osm-tag key="piste:difficulty" renderable="false" value="freeride" />
+
+        <osm-tag key="tracktype" renderable="false" value="grade1" />
+        <osm-tag key="tracktype" renderable="false" value="grade2" />
+        <osm-tag key="tracktype" renderable="false" value="grade3" />
+        <osm-tag key="tracktype" renderable="false" value="grade4" />
+        <osm-tag key="tracktype" renderable="false" value="grade5" />
+
+        <osm-tag key="wood" renderable="false" value="coniferous" />
+        <osm-tag key="wood" renderable="false" value="deciduous" />
+        <osm-tag key="wood" renderable="false" value="mixed" />
+    </ways>
+</tag-mapping>


### PR DESCRIPTION
Add script for building a single map. This will also not delete the data directory and allow for successive runs without downloading from OSM each time.

Add a script that downloads a full region and clips it to a bounding box. This is needed for regions that are not separate Geofabrik regions (e.g. Bahamas, Bermuda, Caribbean islands, South pacific Islands).

Add a buffer size to the perl script and to the input to map-creator (and variants). This is a workaround to a bug where converting the clipped land polygons from shapefiles to OSM files sometimes removes rectangular (tile boundaries?) regions of the land polygon. Altering the buffer size can allow it to work properly.