### PR TITLE
Update tag mapping. 

### DIFF
--- a/tag-mapping.xml
+++ b/tag-mapping.xml
@@ -16,28 +16,17 @@
 
     <!-- PUBLIC AMENITIES -->
     <pois>
-        <osm-tag key="amenity" value="atm" zoom-appear="15" />
-        <osm-tag key="amenity" value="bank" zoom-appear="15" />
         <!-- <osm-tag key="amenity" value="bar" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="bench" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="bicycle_rental" zoom-appear="15" />
-        <!-- <osm-tag key="amenity" value="bus_station" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="cafe" zoom-appear="15" />
         <!-- <osm-tag key="amenity" value="cinema" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="drinking_water" zoom-appear="15" />
+        <!-- <osm-tag key="amenity" value="bus_station" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="fast_food" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="fountain" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="fire_station" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="fuel" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="grave_yard" zoom-appear="15" />
-        <osm-tag key="amenity" value="hospital" zoom-appear="15" />
         <!-- <osm-tag key="amenity" value="kindergarten" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="library" zoom-appear="15" />
         <!-- <osm-tag key="amenity" value="parking" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="pharmacy" zoom-appear="15" />
         <!-- <osm-tag key="amenity" value="place_of_worship" zoom-appear="15" /> -->
-        <osm-tag key="amenity" value="police" zoom-appear="15" />
-        <osm-tag key="amenity" value="post_box" zoom-appear="15" />
         <!-- <osm-tag key="amenity" value="post_office" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="pub" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="recycling" zoom-appear="15" /> -->
@@ -47,6 +36,17 @@
         <!-- <osm-tag key="amenity" value="telephone" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="theatre" zoom-appear="15" /> -->
         <!-- <osm-tag key="amenity" value="townhall" zoom-appear="15" /> -->
+        <osm-tag key="amenity" value="atm" zoom-appear="15" />
+        <osm-tag key="amenity" value="bank" zoom-appear="15" />
+        <osm-tag key="amenity" value="bicycle_rental" zoom-appear="15" />
+        <osm-tag key="amenity" value="cafe" zoom-appear="15" />
+        <osm-tag key="amenity" value="drinking_water" zoom-appear="15" />
+        <osm-tag key="amenity" value="grave_yard" zoom-appear="15" />
+        <osm-tag key="amenity" value="hospital" zoom-appear="15" />
+        <osm-tag key="amenity" value="library" zoom-appear="15" />
+        <osm-tag key="amenity" value="pharmacy" zoom-appear="15" />
+        <osm-tag key="amenity" value="police" zoom-appear="15" />
+        <osm-tag key="amenity" value="post_box" zoom-appear="15" />
         <osm-tag key="amenity" value="toilets" zoom-appear="15" />
         <osm-tag key="amenity" value="university" zoom-appear="15" />
 
@@ -92,22 +92,21 @@
         <!-- <osm-tag key="tourism" value="alpine_hut" zoom-appear="15" /> -->
         <!-- <osm-tag key="tourism" value="artwork" zoom-appear="17" /> -->
         <!-- <osm-tag key="tourism" value="attraction" zoom-appear="17" /> -->
-        <osm-tag key="tourism" value="camp_site" zoom-appear="17" />
-        <!-- <osm-tag key="tourism" value="hostel" zoom-appear="17" /> -->
         <!-- <osm-tag key="tourism" value="hotel" zoom-appear="17" /> -->
         <!-- <osm-tag key="tourism" value="information" zoom-appear="17" /> -->
         <!-- <osm-tag key="tourism" value="museum" zoom-appear="17" /> -->
-        <osm-tag key="tourism" value="picnic_site" zoom-appear="15" />
-        <osm-tag key="tourism" value="viewpoint" zoom-appear="15" />
-
         <!-- <osm-tag key="historic" value="memorial" zoom-appear="17" /> -->
         <!-- <osm-tag key="historic" value="monument" zoom-appear="17" /> -->
+        <osm-tag key="tourism" value="hostel" zoom-appear="17" />
+        <osm-tag key="tourism" value="camp_site" zoom-appear="14" />
+        <osm-tag key="tourism" value="picnic_site" zoom-appear="14" />
+        <osm-tag key="tourism" value="viewpoint" zoom-appear="14" />
     </pois>
 
     <!-- PLACES TAGS -->
     <pois>
-        <osm-tag key="place" value="city" zoom-appear="6" />
-        <osm-tag key="place" value="country" zoom-appear="3" />
+        <osm-tag key="place" value="city" zoom-appear="8" />
+        <osm-tag key="place" value="country" zoom-appear="8" />
         <osm-tag key="place" value="hamlet" zoom-appear="13" />
         <osm-tag key="place" value="island" zoom-appear="12" />
         <osm-tag key="place" value="locality" zoom-appear="13" />
@@ -159,69 +158,47 @@
 
     <!-- HIGHWAY TAGS -->
     <ways>
-        <osm-tag key="highway" value="bridleway" zoom-appear="13" />
-        <!-- <osm-tag key="highway" value="bus_guideway" zoom-appear="13" /> -->
-        <!-- <osm-tag key="highway" value="byway" zoom-appear="13" /> -->
-        <!-- <osm-tag key="highway" value="construction" zoom-appear="13" /> -->
-        <osm-tag key="highway" value="cycleway" zoom-appear="13" />
-        <osm-tag key="highway" value="footway" zoom-appear="14" />
-        <osm-tag key="highway" value="living_street" zoom-appear="13" />
-        <osm-tag key="highway" value="motorway" zoom-appear="6" />
-        <osm-tag key="highway" value="motorway_link" zoom-appear="6" />
-        <osm-tag key="highway" value="path" zoom-appear="14" />
-        <osm-tag key="highway" value="pedestrian" zoom-appear="14" />
+        <osm-tag key="highway" value="motorway" zoom-appear="8" />
+        <osm-tag key="highway" value="motorway_link" zoom-appear="8" />
+        <osm-tag key="highway" value="trunk" zoom-appear="8" />
+        <osm-tag key="highway" value="trunk_link" zoom-appear="8" />
         <osm-tag key="highway" value="primary" zoom-appear="8" />
         <osm-tag key="highway" value="primary_link" zoom-appear="8" />
-        <osm-tag key="highway" value="raceway" zoom-appear="12" />
-        <osm-tag key="highway" value="residential" zoom-appear="12" />
-        <osm-tag key="highway" value="road" zoom-appear="12" />
-        <osm-tag key="highway" value="secondary" zoom-appear="12" />
-        <osm-tag key="highway" value="secondary_link" zoom-appear="12" />
-        <osm-tag key="highway" value="service" zoom-appear="14" />
-        <!-- <osm-tag key="highway" value="services" zoom-appear="14" /> -->
-        <!-- <osm-tag key="highway" value="steps" zoom-appear="16" /> -->
-        <osm-tag key="highway" value="tertiary" zoom-appear="12" />
-        <osm-tag key="highway" value="tertiary_link" zoom-appear="12" />
-        <osm-tag key="highway" value="track" zoom-appear="13" />
-        <osm-tag key="highway" value="trunk" zoom-appear="6" />
-        <osm-tag key="highway" value="trunk_link" zoom-appear="6" />
+        <osm-tag key="highway" value="secondary" zoom-appear="10" />
+        <osm-tag key="highway" value="secondary_link" zoom-appear="10" />
+        <osm-tag key="highway" value="tertiary" zoom-appear="11" />
+        <osm-tag key="highway" value="tertiary_link" zoom-appear="11" />
         <osm-tag key="highway" value="unclassified" zoom-appear="12" />
+        <osm-tag key="highway" value="road" zoom-appear="12" />
+        <osm-tag key="highway" value="residential" zoom-appear="13" />
+        <osm-tag key="highway" value="raceway" zoom-appear="13" />
+        <osm-tag key="highway" value="path" zoom-appear="13" />
+        <osm-tag key="highway" value="track" zoom-appear="13" />
+        <osm-tag key="highway" value="cycleway" zoom-appear="13" />
+        <osm-tag key="highway" value="bridleway" zoom-appear="13" />
+        <osm-tag key="highway" value="living_street" zoom-appear="14" />
+        <osm-tag key="highway" value="pedestrian" zoom-appear="14" />
+        <osm-tag key="highway" value="footway" zoom-appear="14" />
+        <osm-tag key="highway" value="service" zoom-appear="15" />
+        <osm-tag key="highway" value="steps" zoom-appear="16" />
     </ways>
 
     <!-- CYCLEWAY TAGS -->
     <ways>
-        <osm-tag key="cycleway" value="lane" zoom-appear="8" />
-        <osm-tag key="cycleway" value="opposite_lane" zoom-appear="8" />
-        <osm-tag key="cycleway" value="opposite" zoom-appear="8" />
-        <osm-tag key="cycleway" value="shared_lane" zoom-appear="8" />
-        <osm-tag key="cycleway" value="share_busway" zoom-appear="8" />
-        <osm-tag key="cycleway" value="shared" zoom-appear="8" />
-        <osm-tag key="cycleway" value="track" zoom-appear="8" />
-        <osm-tag key="cycleway" value="opposite_track" zoom-appear="8" />
-        <osm-tag key="cycleway" value="cyclestreet" zoom-appear="8" />
-    </ways>
-    <ways>
         <osm-tag key="route" value="bicycle" zoom-appear="8" />
-    </ways>
-    <ways>
-        <osm-tag key="bicycle" value="designated" zoom-appear="8" />
-        <osm-tag key="bicycle" value="yes" zoom-appear="8" />
+        <osm-tag key="bicycle_road" value="yes" zoom-appear="8" />
     </ways>
 
     <!-- NATURAL / WATERWAY TAGS -->
     <ways>
-        <!-- <osm-tag key="leaf_type" renderable="false" value="broadleaved" />
-        <osm-tag key="leaf_type" renderable="false" value="needleleaved" />
-        <osm-tag key="leaf_type" renderable="false" value="leafless" />
-
         <osm-tag key="lock" value="yes" zoom-appear="14" /> -->
 
         <!-- mapsforge artificial tags for land/sea areas, do not remove -->
-        <osm-tag key="natural" value="sea" zoom-appear="0" />
-        <osm-tag key="natural" value="nosea" zoom-appear="0" />
+        <osm-tag key="natural" value="sea" zoom-appear="8" />
+        <osm-tag key="natural" value="nosea" zoom-appear="8" />
 
         <osm-tag key="natural" value="beach" zoom-appear="10" />
-        <!-- <osm-tag key="natural" value="coastline" zoom-appear="0" /> -->
+        <!-- <osm-tag key="natural" value="coastline" zoom-appear="8" /> -->
         <!-- <osm-tag key="natural" value="fell" zoom-appear="10" /> -->
         <!-- <osm-tag enabled="false" key="natural" value="glacier" zoom-appear="8" /> -->
         <osm-tag key="natural" value="grassland" zoom-appear="10" />
@@ -244,33 +221,34 @@
 
     <!-- LANDUSE TAGS -->
     <ways>
-        <!-- <osm-tag key="landuse" value="allotments" zoom-appear="10" /> -->
+        <osm-tag key="landuse" label-position="true" value="wood" zoom-appear="8" />
+        <osm-tag key="landuse" label-position="true" value="forest" zoom-appear="8" />
+        <osm-tag key="landuse" label-position="true" value="cemetery" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="commercial" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="residential" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="industrial" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="brownfield" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="military" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="quarry" zoom-appear="10" />
+	<osm-tag key="landuse" label-position="true" value="recreation_ground" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="reservoir" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="retail" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="farm" zoom-appear="12" />
+        <osm-tag key="landuse" label-position="true" value="allotments" zoom-appear="10" />
+        <osm-tag key="landuse" label-position="true" value="farmland" zoom-appear="12" />
+        <osm-tag key="landuse" label-position="true" value="farmyard" zoom-appear="12" />
+        <osm-tag key="landuse" label-position="true" value="grass" zoom-appear="12" />
+        <osm-tag key="landuse" label-position="true" value="meadow" zoom-appear="12" />
+        <osm-tag key="landuse" label-position="true" value="orchard" zoom-appear="12" />
+        <osm-tag key="landuse" label-position="true" value="vineyard" zoom-appear="12" />
+
         <!-- <osm-tag key="landuse" value="basin" zoom-appear="12" /> -->
-        <!-- <osm-tag key="landuse" value="brownfield" zoom-appear="10" /> -->
-        <osm-tag key="landuse" value="cemetery" zoom-appear="10" />
-        <!-- <osm-tag key="landuse" value="commercial" zoom-appear="10" /> -->
         <!-- <osm-tag key="landuse" value="construction" zoom-appear="12" /> -->
-        <osm-tag key="landuse" value="farm" zoom-appear="12" />
-        <osm-tag key="landuse" value="farmland" zoom-appear="12" />
         <!-- <osm-tag key="landuse" value="factory" zoom-appear="12" /> -->
-        <osm-tag key="landuse" value="farmyard" zoom-appear="12" />
-        <osm-tag key="landuse" value="forest" zoom-appear="8" />
-        <osm-tag key="landuse" value="grass" zoom-appear="12" />
         <!-- <osm-tag key="landuse" value="greenfield" zoom-appear="12" /> -->
-        <!-- <osm-tag key="landuse" value="industrial" zoom-appear="10" /> -->
         <!-- <osm-tag key="landuse" value="landfill" zoom-appear="12" /> -->
-        <osm-tag key="landuse" value="meadow" zoom-appear="12" />
-        <!-- <osm-tag key="landuse" value="military" zoom-appear="10" /> -->
-        <osm-tag key="landuse" value="orchard" zoom-appear="12" />
-        <!-- <osm-tag key="landuse" value="quarry" zoom-appear="10" /> -->
         <!-- <osm-tag key="landuse" value="railway" zoom-appear="10" /> -->
-        <!-- <osm-tag key="landuse" value="recreation_ground" zoom-appear="10" /> -->
-        <!-- <osm-tag key="landuse" value="reservoir" zoom-appear="10" /> -->
-        <!-- <osm-tag key="landuse" value="residential" zoom-appear="10" /> -->
-        <!-- <osm-tag key="landuse" value="retail" zoom-appear="10" /> -->
         <!-- <osm-tag key="landuse" value="village_green" zoom-appear="10" /> -->
-        <!-- <osm-tag key="landuse" value="vineyard" zoom-appear="12" /> -->
-        <osm-tag key="landuse" value="wood" zoom-appear="8" />
     </ways>
 
     <!-- LEISURE/SPORT TAGS -->
@@ -278,17 +256,16 @@
         <osm-tag key="leisure" value="common" zoom-appear="12" />
         <!-- <osm-tag key="leisure" value="dog_park" zoom-appear="12" /> -->
         <osm-tag key="leisure" value="garden" zoom-appear="12" />
-        <osm-tag key="leisure" value="golf_course" zoom-appear="12" />
-        <osm-tag key="leisure" value="nature_reserve" zoom-appear="12" />
-        <osm-tag key="leisure" value="park" zoom-appear="10" />
-        <osm-tag key="leisure" value="pitch" zoom-appear="12" />
+        <osm-tag key="leisure" label-position="true" value="golf_course" zoom-appear="12" />
+        <osm-tag key="leisure" label-position="true" value="nature_reserve" zoom-appear="12" />
+        <osm-tag key="leisure" label-position="true" value="park" zoom-appear="10" />
+        <osm-tag key="leisure" label-position="true" value="pitch" zoom-appear="12" />
         <!-- <osm-tag key="leisure" value="playground" zoom-appear="12" /> -->
         <!-- <osm-tag key="leisure" value="sports_centre" zoom-appear="12" /> -->
         <!-- <osm-tag key="leisure" value="stadium" zoom-appear="10" /> -->
         <!-- <osm-tag key="leisure" value="swimming_pool" zoom-appear="14" /> -->
         <!-- <osm-tag key="leisure" value="track" zoom-appear="12" /> -->
         <!-- <osm-tag key="leisure" value="water_park" zoom-appear="12" /> -->
-
         <!-- <osm-tag key="sport" value="golf" zoom-appear="12" />
         <osm-tag key="sport" value="soccer" zoom-appear="12" />
         <osm-tag key="sport" value="swimming" zoom-appear="12" />
@@ -306,34 +283,27 @@
         <osm-tag key="sport" value="equestrian" zoom-appear="12" />
         <osm-tag key="sport" value="bowls" zoom-appear="12" />
         <osm-tag key="sport" value="multi" zoom-appear="12" /> -->
-
     </ways>
 
     <!-- PUBLIC AMENITIES -->
     <ways>
-        <osm-tag key="amenity" value="college" zoom-appear="13" />
+        <osm-tag key="amenity" label-position="true" value="college" zoom-appear="13" />
+        <osm-tag key="amenity" label-position="true" value="hospital" zoom-appear="13" />
+        <osm-tag key="amenity" label-position="true" value="university" zoom-appear="13" />
+        <osm-tag key="amenity" label-position="true" value="parking" zoom-appear="14" />
+        <osm-tag key="amenity" label-position="true" value="school" zoom-appear="14" />
         <!-- <osm-tag key="amenity" value="embassy" zoom-appear="13" /> -->
         <!-- <osm-tag key="amenity" value="fountain" zoom-appear="16" /> -->
         <!-- <osm-tag key="amenity" value="grave_yard" zoom-appear="14" /> -->
-        <osm-tag key="amenity" value="hospital" zoom-appear="13" />
-        <osm-tag key="amenity" value="parking" zoom-appear="14" />
         <!-- <osm-tag key="amenity" value="place_of_worship" zoom-appear="14" /> -->
-        <osm-tag key="amenity" value="school" zoom-appear="14" />
         <!-- <osm-tag key="amenity" value="swimming_pool" zoom-appear="14" /> -->
         <!-- <osm-tag key="amenity" value="theatre" zoom-appear="14" /> -->
         <!-- <osm-tag key="amenity" value="toilets" zoom-appear="17" /> -->
-        <osm-tag key="amenity" value="university" zoom-appear="13" />
-
-        <!-- <osm-tag key="religion" renderable="false" value="buddhist" />
-        <osm-tag key="religion" renderable="false" value="christian" />
-        <osm-tag key="religion" renderable="false" value="hindu" />
-        <osm-tag key="religion" renderable="false" value="jewish" />
-        <osm-tag key="religion" renderable="false" value="muslim" />
-        <osm-tag key="religion" renderable="false" value="shinto" /> -->
 
         <!-- <osm-tag key="tourism" value="attraction" zoom-appear="14" />
         <osm-tag key="tourism" value="hostel" zoom-appear="15" />
-        <osm-tag key="tourism" value="zoo" zoom-appear="12" /> -->
+        <osm-tag key="tourism" label-position="true" value="zoo" zoom-appear="12" /> -->
+        <osm-tag key="tourism" label-position="true" value="caravan_site" zoom-appear="14" />
     </ways>
 
     <!-- PUBLIC TRANSPORT -->
@@ -355,82 +325,82 @@
 
     <!-- BUILDINGS -->
     <ways>
-        <osm-tag key="building" label-position="true" value="apartment" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="apartments" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="barn" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="block" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="building" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="cabin" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="castle" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="cathedral" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="chapel" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="church" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="civic" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="commercial" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="detached" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="garage" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="garages" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="embassy" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="factory" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="farm" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="farm_auxiliary" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="government" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="greenhouse" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="gym" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="hangar" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="hotel" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="hospital" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="house" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="hut" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="industrial" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="library" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="manufacture" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="monastery" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="mosque" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="museum" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="office" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="public" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="residential" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="Residential" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="retail" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="roof" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="ruins" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="school" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="service" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="semidetached_house" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="shed" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="shelter" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="shop" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="sports" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="supermarket" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="terrace" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="transportation" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="train_station" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="university" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="wall" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="warehouse" zoom-appear="17" />
-        <osm-tag key="building" label-position="true" value="yes" zoom-appear="17" />
+        <osm-tag key="building" value="apartment" zoom-appear="17" />
+        <osm-tag key="building" value="apartments" zoom-appear="17" />
+        <osm-tag key="building" value="barn" zoom-appear="17" />
+        <osm-tag key="building" value="block" zoom-appear="17" />
+        <osm-tag key="building" value="building" zoom-appear="17" />
+        <osm-tag key="building" value="cabin" zoom-appear="17" />
+        <osm-tag key="building" value="castle" zoom-appear="17" />
+        <osm-tag key="building" value="cathedral" zoom-appear="17" />
+        <osm-tag key="building" value="chapel" zoom-appear="17" />
+        <osm-tag key="building" value="church" zoom-appear="17" />
+        <osm-tag key="building" value="civic" zoom-appear="17" />
+        <osm-tag key="building" value="commercial" zoom-appear="17" />
+        <osm-tag key="building" value="detached" zoom-appear="17" />
+        <osm-tag key="building" value="garage" zoom-appear="17" />
+        <osm-tag key="building" value="garages" zoom-appear="17" />
+        <osm-tag key="building" value="embassy" zoom-appear="17" />
+        <osm-tag key="building" value="factory" zoom-appear="17" />
+        <osm-tag key="building" value="farm" zoom-appear="17" />
+        <osm-tag key="building" value="farm_auxiliary" zoom-appear="17" />
+        <osm-tag key="building" value="government" zoom-appear="17" />
+        <osm-tag key="building" value="greenhouse" zoom-appear="17" />
+        <osm-tag key="building" value="gym" zoom-appear="17" />
+        <osm-tag key="building" value="hangar" zoom-appear="17" />
+        <osm-tag key="building" value="hotel" zoom-appear="17" />
+        <osm-tag key="building" value="hospital" zoom-appear="17" />
+        <osm-tag key="building" value="house" zoom-appear="17" />
+        <osm-tag key="building" value="hut" zoom-appear="17" />
+        <osm-tag key="building" value="industrial" zoom-appear="17" />
+        <osm-tag key="building" value="library" zoom-appear="17" />
+        <osm-tag key="building" value="manufacture" zoom-appear="17" />
+        <osm-tag key="building" value="monastery" zoom-appear="17" />
+        <osm-tag key="building" value="mosque" zoom-appear="17" />
+        <osm-tag key="building" value="museum" zoom-appear="17" />
+        <osm-tag key="building" value="office" zoom-appear="17" />
+        <osm-tag key="building" value="public" zoom-appear="17" />
+        <osm-tag key="building" value="residential" zoom-appear="17" />
+        <osm-tag key="building" value="Residential" zoom-appear="17" />
+        <osm-tag key="building" value="retail" zoom-appear="17" />
+        <osm-tag key="building" value="roof" zoom-appear="17" />
+        <osm-tag key="building" value="ruins" zoom-appear="17" />
+        <osm-tag key="building" value="school" zoom-appear="17" />
+        <osm-tag key="building" value="service" zoom-appear="17" />
+        <osm-tag key="building" value="semidetached_house" zoom-appear="17" />
+        <osm-tag key="building" value="shed" zoom-appear="17" />
+        <osm-tag key="building" value="shelter" zoom-appear="17" />
+        <osm-tag key="building" value="shop" zoom-appear="17" />
+        <osm-tag key="building" value="sports" zoom-appear="17" />
+        <osm-tag key="building" value="supermarket" zoom-appear="17" />
+        <osm-tag key="building" value="terrace" zoom-appear="17" />
+        <osm-tag key="building" value="transportation" zoom-appear="17" />
+        <osm-tag key="building" value="train_station" zoom-appear="17" />
+        <osm-tag key="building" value="university" zoom-appear="17" />
+        <osm-tag key="building" value="wall" zoom-appear="17" />
+        <osm-tag key="building" value="warehouse" zoom-appear="17" />
+        <osm-tag key="building" value="yes" zoom-appear="17" />
     </ways>
 
     <!-- ADMINISTRATIVE BOUNDARIES -->
     <ways>
 
-        <osm-tag force-polygon-line="true" key="admin_level" value="1" zoom-appear="4">
+        <osm-tag force-polygon-line="true" key="admin_level" value="1" zoom-appear="8">
             <zoom-override key="boundary" value="administrative" />
         </osm-tag>
-        <osm-tag force-polygon-line="true" key="admin_level" value="2" zoom-appear="4">
+        <osm-tag force-polygon-line="true" key="admin_level" value="2" zoom-appear="8">
             <zoom-override key="boundary" value="administrative" />
         </osm-tag>
-        <osm-tag force-polygon-line="true" key="admin_level" value="3" zoom-appear="4">
+        <osm-tag force-polygon-line="true" key="admin_level" value="3" zoom-appear="8">
             <zoom-override key="boundary" value="administrative" />
         </osm-tag>
-        <osm-tag force-polygon-line="true" key="admin_level" value="4" zoom-appear="6">
+        <osm-tag force-polygon-line="true" key="admin_level" value="4" zoom-appear="8">
             <zoom-override key="boundary" value="administrative" />
         </osm-tag>
-        <osm-tag force-polygon-line="true" key="admin_level" value="5" zoom-appear="6">
+        <osm-tag force-polygon-line="true" key="admin_level" value="5" zoom-appear="8">
             <zoom-override key="boundary" value="administrative" />
         </osm-tag>
-        <osm-tag force-polygon-line="true" key="admin_level" value="6" zoom-appear="6">
+        <osm-tag force-polygon-line="true" key="admin_level" value="6" zoom-appear="8">
             <zoom-override key="boundary" value="administrative" />
         </osm-tag>
         <!-- <osm-tag key="admin_level" value="6" force-polygon-line="true" zoom-appear="15" /> <osm-tag key="admin_level" value="8"
@@ -469,7 +439,7 @@
         <!-- <osm-tag key="barrier" value="retaining_wall" zoom-appear="16" /> -->
         <!-- <osm-tag key="barrier" value="wall" zoom-appear="16" /> -->
 
-        <!-- <osm-tag force-polygon-line="true" key="boundary" value="administrative" zoom-appear="0" /> -->
+        <!-- <osm-tag force-polygon-line="true" key="boundary" value="administrative" zoom-appear="8" /> -->
         <!-- <osm-tag key="boundary" value="national_park" zoom-appear="12" /> -->
 
         <!-- <osm-tag key="historic" value="ruins" zoom-appear="17" /> -->
@@ -488,10 +458,42 @@
 
     <!-- NOT TO RENDER -->
     <ways>
-        <osm-tag key="id" renderable="false" value="%f" />
+        <!-- osm-tag key="id" renderable="false" value="%f" /> -->
+        <!-- osm-tag key="access" renderable="false" value="destination" /> -->
+        <!-- osm-tag key="access" renderable="false" value="private" /> -->
 
-        <osm-tag key="access" renderable="false" value="destination" />
-        <osm-tag key="access" renderable="false" value="private" />
+        <osm-tag key="bicycle" renderable="false" value="designated" />
+        <osm-tag key="bicycle" renderable="false" value="yes" />
+
+        <!-- Cycleway tags (not highway:cycleway) represent bicycle lanes attached to ways /> -->
+        <osm-tag key="cycleway" renderable="false" value="lane" />
+        <osm-tag key="cycleway" renderable="false" value="opposite_lane" />
+        <osm-tag key="cycleway" renderable="false" value="opposite" />
+        <osm-tag key="cycleway" renderable="false" value="shared_lane" />
+        <osm-tag key="cycleway" renderable="false" value="share_busway" />
+        <osm-tag key="cycleway" renderable="false" value="shared" />
+        <osm-tag key="cycleway" renderable="false" value="track" />
+        <osm-tag key="cycleway" renderable="false" value="opposite_track" />
+        <osm-tag key="cycleway" renderable="false" value="cyclestreet" />
+
+        <osm-tag key="mtb:scale" renderable="false" value="0" />
+        <osm-tag key="mtb:scale" renderable="false" value="1" />
+        <osm-tag key="mtb:scale" renderable="false" value="2" />
+        <osm-tag key="mtb:scale" renderable="false" value="3" />
+        <osm-tag key="mtb:scale" renderable="false" value="4" />
+        <osm-tag key="mtb:scale" renderable="false" value="5" />
+        <osm-tag key="mtb:scale" renderable="false" value="6" />
+        <osm-tag key="mtb:scale:uphill" renderable="false" value="0" />
+        <osm-tag key="mtb:scale:uphill" renderable="false" value="1" />
+        <osm-tag key="mtb:scale:uphill" renderable="false" value="2" />
+        <osm-tag key="mtb:scale:uphill" renderable="false" value="3" />
+        <osm-tag key="mtb:scale:uphill" renderable="false" value="4" />
+        <osm-tag key="mtb:scale:uphill" renderable="false" value="5" />
+        <osm-tag key="mtb:scale:imba" renderable="false" value="0" />
+        <osm-tag key="mtb:scale:imba" renderable="false" value="1" />
+        <osm-tag key="mtb:scale:imba" renderable="false" value="2" />
+        <osm-tag key="mtb:scale:imba" renderable="false" value="3" />
+        <osm-tag key="mtb:scale:imba" renderable="false" value="4" />
 
         <osm-tag key="bridge" renderable="false" value="yes" />
 
@@ -499,21 +501,26 @@
         <osm-tag key="oneway" renderable="false" value="-1" />
         <osm-tag equivalent-values="0,false" key="oneway" renderable="false" value="no" />
 
-        <osm-tag key="piste:difficulty" renderable="false" value="novice" />
-        <osm-tag key="piste:difficulty" renderable="false" value="easy" />
-        <osm-tag key="piste:difficulty" renderable="false" value="intermediate" />
-        <osm-tag key="piste:difficulty" renderable="false" value="advanced" />
-        <osm-tag key="piste:difficulty" renderable="false" value="expert" />
-        <osm-tag key="piste:difficulty" renderable="false" value="freeride" />
+        <!-- SURFACE TAGS -->
+	<osm-tag key="surface" renderable="false" value="unpaved" />
+        <osm-tag key="surface" renderable="false" value="compacted" />
+        <osm-tag key="surface" renderable="false" value="ground" />
+        <osm-tag key="surface" renderable="false" value="gravel" />
+        <osm-tag key="surface" renderable="false" value="dirt" />
+        <osm-tag key="surface" renderable="false" value="grass" />
+        <osm-tag key="surface" renderable="false" value="sand" />
+        <osm-tag key="surface" renderable="false" value="fine_gravel" />
 
+        <!-- SERVICE TAGS -->
+	<osm-tag key="service" renderable="false" value="driveway" />
+	<osm-tag key="service" renderable="false" value="parking_aisle" />
+	<osm-tag key="service" renderable="false" value="alley" />
+
+        <!-- Tracktype can represent the surface type of track ways /> -->
         <osm-tag key="tracktype" renderable="false" value="grade1" />
         <osm-tag key="tracktype" renderable="false" value="grade2" />
         <osm-tag key="tracktype" renderable="false" value="grade3" />
         <osm-tag key="tracktype" renderable="false" value="grade4" />
         <osm-tag key="tracktype" renderable="false" value="grade5" />
-
-        <osm-tag key="wood" renderable="false" value="coniferous" />
-        <osm-tag key="wood" renderable="false" value="deciduous" />
-        <osm-tag key="wood" renderable="false" value="mixed" />
     </ways>
 </tag-mapping>


### PR DESCRIPTION
Add several tags (renderable=false) to support style updates for cycling: mtb:scale, surface tags primarily. Add some land-use area features and enable label_position for these. Turn off label position
for buildings to save space.